### PR TITLE
Patch to work on all image URLs

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "Chrome Image Uncenterer",
-	"version": "0.0.1",
+	"version": "0.0.2",
 	"manifest_version": 2,
 	"description": "Un-centers the image viewer introduced in Chrome 56.0+",
 	"homepage_url": "http://github.com/i-a-n/chrome-image-uncenterer",
@@ -11,13 +11,7 @@
 	},
 	"content_scripts": [{
 		"matches": [
-			"*://*/*.jpg*",
-			"*://*/*.jpeg*",
-			"*://*/*.gif*",
-			"*://*/*.svg*",
-			"*://*/*.png*",
-			"*://*/*.tiff*",
-			"*://*/*.bmp*"
+			"<all_urls>"
 		],
 		"css": [
 			"src/inject/inject.css"

--- a/src/inject/inject.css
+++ b/src/inject/inject.css
@@ -1,8 +1,10 @@
-body {
-	background: white !important;
-}
-body > img:only-child {
-	position: absolute !important;
-	top: 0 !important;
-	left: 0 !important;
+@media not print {
+	body[style="margin: 0px; background: rgb(14, 14, 14);"] {
+		background: white !important;
+	}
+	body[style="margin: 0px; background: rgb(14, 14, 14);"] > img:only-child {
+		position: absolute !important;
+		top: 0 !important;
+		left: 0 !important;
+	}
 }


### PR DESCRIPTION
Hey,

I noticed that your extension doesn't work on all image URLs when I looked at the reviews in the Chrome store. After doing a lot of tinkering with your extension, I got it to work perfectly via MIME-type determination, but this caused an undesirable flash when the page was loaded, so I dug around some more and found https://github.com/mdamien/chrome-extension-image-center, whose code I modified and partially reused to get your extension working universally on all pages without drastically raising the probability of running into a CSS conflict from having to inject the CSS on every page. Anyways, the extension seems to work perfectly on all images now - the URL doesn't matter anymore, so cases like the one mentioned in the review that inspired this are handled properly.

I've never opened a pull request before so I hope I'm doing this properly.

Thanks.