### PR TITLE
Remove checkered transparency

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "Chrome Image Uncenterer",
-	"version": "0.1.0",
+	"version": "0.3.0",
 	"manifest_version": 2,
 	"description": "Un-centers the image viewer introduced in Chrome 56.0+",
 	"homepage_url": "http://github.com/i-a-n/chrome-image-uncenterer",

--- a/src/inject/inject.css
+++ b/src/inject/inject.css
@@ -5,6 +5,9 @@
 	}
 	body[style="margin: 0px; background: rgb(14, 14, 14);"] > img:only-child,
 	body[style="margin: 0px; background: #0e0e0e;"] > img:only-child {
+		background-image: initial !important;
+		background-position: 0px !important;
+		background-size: 0px !important;
 		position: absolute !important;
 		top: 0 !important;
 		left: 0 !important;


### PR DESCRIPTION
Removes the checker pattern in images with transparency, which wasn't present in older versions of Chrome.