### PR TITLE
Make selectors more lenient.

### DIFF
--- a/src/inject/inject.css
+++ b/src/inject/inject.css
@@ -1,12 +1,10 @@
-@media not print {
-	body[style="margin: 0px; background: rgb(14, 14, 14);"],
-	body[style="margin: 0px; background: #0e0e0e;"] {
-		background: white !important;
-	}
-	body[style="margin: 0px; background: rgb(14, 14, 14);"] > img:only-child,
-	body[style="margin: 0px; background: #0e0e0e;"] > img:only-child {
-		position: absolute !important;
-		top: 0 !important;
-		left: 0 !important;
-	}
+body[style="margin: 0px; background: rgb(14, 14, 14);"],
+body[style="margin: 0px; background: #0e0e0e;"] {
+    background: white !important;
+}
+body[style="margin: 0px; background: rgb(14, 14, 14);"] > img,
+body[style="margin: 0px; background: #0e0e0e;"] > img {
+    position: absolute !important;
+    top: 0 !important;
+    left: 0 !important;
 }


### PR DESCRIPTION
Remove `@media not print` and `:only-child` to make the rules target images again.