### PR TITLE
Fix selectors to address issues from Chrome updates and various third-party extensions

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "Chrome Image Uncenterer",
-	"version": "0.1.0",
+	"version": "0.2.1",
 	"manifest_version": 2,
 	"description": "Un-centers the image viewer introduced in Chrome 56.0+",
 	"homepage_url": "http://github.com/i-a-n/chrome-image-uncenterer",

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "Chrome Image Uncenterer",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"manifest_version": 2,
 	"description": "Un-centers the image viewer introduced in Chrome 56.0+",
 	"homepage_url": "https://github.com/i-a-n/chrome-image-uncenterer",

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
 	"name": "Chrome Image Uncenterer",
-	"version": "0.2.1",
+	"version": "0.1.1",
 	"manifest_version": 2,
 	"description": "Un-centers the image viewer introduced in Chrome 56.0+",
-	"homepage_url": "http://github.com/i-a-n/chrome-image-uncenterer",
+	"homepage_url": "https://github.com/i-a-n/chrome-image-uncenterer",
 	"icons": {
 		"16": "icons/icon16.png",
 		"48": "icons/icon48.png",

--- a/src/inject/inject.css
+++ b/src/inject/inject.css
@@ -3,8 +3,9 @@
 	body[style="margin: 0px; background: #0e0e0e;"] {
 		background: white !important;
 	}
-	body[style="margin: 0px; background: rgb(14, 14, 14);"] > img:only-child,
-	body[style="margin: 0px; background: #0e0e0e;"] > img:only-child {
+	
+	body[style="margin: 0px; background: rgb(14, 14, 14);"] > img:first-child,
+	body[style="margin: 0px; background: #0e0e0e;"] > img:first-child {
 		position: absolute !important;
 		top: 0 !important;
 		left: 0 !important;

--- a/src/inject/inject.css
+++ b/src/inject/inject.css
@@ -1,11 +1,11 @@
 @media not print {
-	body[style="margin: 0px; background: rgb(14, 14, 14);"],
-	body[style="margin: 0px; background: #0e0e0e;"] {
+	body[style="margin: 0px; background: rgb(14, 14, 14); height: 100%"],
+	body[style="margin: 0px; background: #0e0e0e; height: 100%"] {
 		background: white !important;
 	}
 	
-	body[style="margin: 0px; background: rgb(14, 14, 14);"] > img:first-child,
-	body[style="margin: 0px; background: #0e0e0e;"] > img:first-child {
+	body[style="margin: 0px; background: rgb(14, 14, 14); height: 100%"] > img:first-child,
+	body[style="margin: 0px; background: #0e0e0e; height: 100%"] > img:first-child {
 		position: absolute !important;
 		top: 0 !important;
 		left: 0 !important;


### PR DESCRIPTION
Fixes all issues noted in #13 by changing selectors from `img:only-child` to `img:first-child`, as well as another unrelated minor issue with the manifest's homepage_url (non-https github.com url).

Tested on both Windows 10 & OS X over the course of more than a year, no issues encountered, seems to work well on both platforms without breaking anything. The `img:first-child` selector appears to be the most conservative option available for reliably resolving the issue, although if anyone has an alternative, I'm all ears.

Edit 1: A subsequent fix for the breakage caused by Chrome 87 has been pushed to this branch. Unlike the previous fixes, this one has not yet been tested on Windows. This addresses issue #16.

Edit 2: I believe that this PR also addresses #9 and #7.